### PR TITLE
fix: ignore callback param w/ dangerous chars (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 test/error.log
 test/httpd.pid
 .libs
+
+# CLion build files
+.idea/
+CMakeLists.txt

--- a/DOCUMENTATION
+++ b/DOCUMENTATION
@@ -81,6 +81,17 @@ directory or .htaccess sections of the configuration.
 
       { "a": "1", "b": "2", "c": "3" }
 
+    The callback parameter is validated to ensure it only contains characters that
+    could be used to define a JS function w/o using quotes on the keys. This prevents
+    arbitrary code execution, but also means the callback cannot be a quoted
+    dereference of a JS object (e.g., a.b.c is ok, but a['b'].c is not). The allowed
+    characters are:
+
+      [a-zA-Z0-9._]
+
+    If the callback does not validate, then the response will be a 400, which can be
+    configured to provide a custom body (see: https://httpd.apache.org/docs/2.4/custom-error.html).
+
 *** C2JSONPrefix directive
     Syntax:     C2JSONPrefix String1 String2 ...
     Default:    NULL

--- a/README.md
+++ b/README.md
@@ -14,13 +14,15 @@ you can get by running:
 ```
 
 From the checkout directory run:
+```
+  $ perl build.pl
+```
+
+This will build the module on your system and is sufficient for running the tests. If you want to build, install & enable the module on your system:
 
 ```
   $ sudo perl build.pl --install
 ```
-
-This will build, install & enable the module on your system
-
 
 Configuration
 -------------
@@ -34,38 +36,43 @@ directives supported.
 Testing
 -------
 
-*** Note: for this will you will need Apache, NodeJS
-*** and Perl installed.
+*** Note:*** for this will need Apache, NodeJS and Perl installed.
 
 First, start the backend node based server. It serves
 as an endpoint and shows you the received url & headers
 for every call:
 
 ```
-  $ test/run_backend.sh
+  $ ./test/run_backend.sh
 ```
 
 Next, start a custom Apache server. This will have all
 the modules needed and the endpoints for testing:
 
 ```
-  $ sudo test/run_httpd.sh
+  $ ./test/run_httpd.sh
 ```
 
 Then, run the test suite:
 
 ```
-  $ perl test/01_all.pl
+  $ perl test/01_all.t
+```
+
+If you are testing in a container environment, `run_tests_docker.sh` is provided as a wrapper to run all these steps (see below for a sample Dockerfile), for example:
+
+```
+  $ docker run -t -w /build -v $(pwd):/build <image_name> ./run_tests_docker.sh
 ```
 
 Run it as follows to enable diagnostic/debug output:
 
 ```
-  $ perl test/01_all.pl --debug
+  $ perl test/01_all.t --debug
 ```
 
 There will be an error log available, and that will be
-especially useful if you built the library with --debug:
+especially useful if you built the library with `--debug`:
 
 ```
   $ tail -F test/error.log
@@ -86,3 +93,7 @@ Then build the package by first compiling the module, then running buildpackage:
 $ perl build.pl
 $ dpkg-buildpackage -d -b
 ```
+
+Using Docker
+------------
+To install all the dependencies and set up `nvm`, see the sample Dockerfile for building on the Trusty release of Ubuntu in `contrib/ubuntu-trusty`

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# one can't do 'docker run <image> <cmd1> && <cmd2>', so we need this teensy wrapper.
+set -ex
+if [ -z $BUILD_DIR ] ; then
+    echo "You must set BUILD_DIR so we are building from the right place"
+    exit 1
+fi
+cd $BUILD_DIR
+perl build.pl
+dpkg-buildpackage -d -b

--- a/contrib/ubuntu-trusty/Dockerfile
+++ b/contrib/ubuntu-trusty/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:trusty
+
+USER root
+ENV HOME /root
+
+ENV NODE_VER 6.2.2
+ENV NVM_DIR=${HOME}/.nvm"
+
+# this update is required to find apache2-dev, which is in updates.
+RUN apt-get update
+RUN apt-get install -y apache2 apache2-dev perl git-core curl libwww-perl dpkg-dev cdbs
+
+# install nvm; use nvm to install node; set up a .profile to be sourced by your test task
+RUN git clone https://github.com/creationix/nvm.git $HOME/.nvm
+RUN echo '. ~/.nvm/nvm.sh' >> $HOME/.profile
+RUN .  ~/.nvm/nvm.sh && nvm install ${NODE_VER} && nvm alias default ${NODE_VER}
+RUN echo 'nvm install ${NODE_VER}' >> $HOME/.profile

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libapache2-mod-cookie2json (1.0.1-2krux2) unstable; urgency=low
+
+  * Updates to test properly on Ubuntu Lucid and build in a docker container
+
+ -- Krux Operations Team <ops@krux.com>  Wed, 29 Jun 2016 22:05:00 +0000
+
 libapache2-mod-cookie2json (1.0.1-2krux1) unstable; urgency=low
 
   * New build to discern between debian versions

--- a/run_tests_docker.sh
+++ b/run_tests_docker.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# this script leaves the node and apache2 processes running,
+# in a non-Docker/container environment, those would need to
+# be cleaned up.
+
+# in support of our docker config
+if [ -f ~/.profile ]; then
+    . ~/.profile
+fi
+perl build.pl
+./test/run_backend.sh &
+./test/run_httpd.sh &
+sleep 1
+perl test/*t

--- a/test/httpd.conf
+++ b/test/httpd.conf
@@ -1,4 +1,19 @@
+<IfModule !version_module>
+  LoadModule version_module /usr/lib/apache2/modules/mod_version.so
+</IfModule>
+
+<IfVersion >= 2.4>
+  LoadModule authz_user_module /usr/lib/apache2/modules/mod_authz_user.so
+  LoadModule authz_core_module /usr/lib/apache2/modules/mod_authz_core.so
+  LoadModule mpm_event_module /usr/lib/apache2/modules/mod_mpm_event.so
+  LoadModule slotmem_shm_module /usr/lib/apache2/modules/mod_slotmem_shm.so
+</IfVersion>
+
+
 ### for proxying to the node server
+<IfVersion >= 2.4>
+  LoadModule lbmethod_byrequests_module /usr/lib/apache2/modules/mod_lbmethod_byrequests.so
+</IfVersion>
 LoadModule proxy_module /usr/lib/apache2/modules/mod_proxy.so
 LoadModule proxy_balancer_module /usr/lib/apache2/modules/mod_proxy_balancer.so
 LoadModule proxy_http_module /usr/lib/apache2/modules/mod_proxy_http.so
@@ -6,15 +21,27 @@ LoadModule proxy_http_module /usr/lib/apache2/modules/mod_proxy_http.so
 ### a bug was preventing headers to be set using this module
 LoadModule headers_module /usr/lib/apache2/modules/mod_headers.so
 
-LoadModule cookie2json_module /usr/lib/apache2/modules/mod_cookie2json.so
+LoadModule cookie2json_module .libs/mod_cookie2json.so
 
 ErrorLog test/error.log
+
+### Setting to 400 to make testing simpler
+ErrorDocument 400 "Bad Request"
+
 PidFile test/httpd.pid
 User www-data
+Group www-data
 
 Listen 7000
-NameVirtualHost *:7000
+ServerName buildhost
 <VirtualHost  *:7000>
+   <IfVersion >= 2.4>
+      <Directory />
+          Require all granted
+      </Directory>
+   </IfVersion>
+
+  ServerName localhost:7000
 
   <Proxy balancer://node>
     BalancerMember http://localhost:7001
@@ -22,6 +49,7 @@ NameVirtualHost *:7000
 
   <Location /none>
     ProxyPass balancer://node
+    Header always set Content-Type "text/plain"
   </Location>
 
   <Location /basic>
@@ -43,8 +71,4 @@ NameVirtualHost *:7000
     C2JSON On
     Header always set X-C2JSON-Header "Not Filtered"
   </Location>
-
-
-
-
 </VirtualHost>


### PR DESCRIPTION
Change ensures we validate JSONP callback parameter.

We've added a small performance optimization using a
character lookup table to avoid the O(n^2) of while with
a strchr call.

Additonally, adds Dockerfile example and basic instructions
for testing w/ docker, which we're using for CI isolation.
